### PR TITLE
Accept a file with extension .EC in META-INF too

### DIFF
--- a/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
+++ b/core/src/main/java/net/sourceforge/jnlp/tools/JarCertVerifier.java
@@ -466,7 +466,7 @@ public class JarCertVerifier implements CertVerifier {
     /**
      * Returns whether a file is in META-INF, and thus does not require signing.
      * <p>
-     * Signature-related files under META-INF include: . META-INF/MANIFEST.MF . META-INF/SIG-* . META-INF/*.SF . META-INF/*.DSA . META-INF/*.RSA
+     * Signature-related files under META-INF include: . META-INF/MANIFEST.MF . META-INF/SIG-* . META-INF/*.SF . META-INF/*.DSA . META-INF/*.RSA . META-INF/*.EC
      */
     static boolean isMetaInfFile(final String name) {
         if (name.endsWith("class")) {
@@ -477,6 +477,7 @@ public class JarCertVerifier implements CertVerifier {
                 name.endsWith(".SF") ||
                 name.endsWith(".DSA") ||
                 name.endsWith(".RSA") ||
+                name.endsWith(".EC") ||
                 SIG.matcher(name).matches()
         );
     }


### PR DESCRIPTION
The elliptic curve signature algorithms like SHA256withECDSA will create a file with extension .EC in the META-INF directory.